### PR TITLE
BacDive API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,11 @@
-# BacDive API
+# BacDive API v2
 
-Using the BacDive API requires registration. Registration is free but the usage of BacDive data is only permitted when in compliance with the BacDive terms of use. See [About BacDive](https://bacdive.dsmz.de/about) for details.
-
-Please register [here](https://api.bacdive.dsmz.de/login).
-
-The Python package can be initialized using your login credentials:
-
+Using the BacDive API does not require registration anymore, but the usage of BacDive data is only permitted when in compliance with the BacDive terms of use. See [About BacDive](https://bacdive.dsmz.de/about) for details.
 
 ```python
 import bacdive
 
-client = bacdive.BacdiveClient('name@mail.example', 'password')
+client = bacdive.BacdiveClient()
 
 # [optional] You may define the search type as one of the following: 
 # 'exact' (default), 'contains', 'startswith', 'endswith'


### PR DESCRIPTION
The BacDive API has moved to version 2 (base url https://api.bacdive.dsmz.de/v2/) due to **changes in the structure of the Genome Sequences data**. 

While v1 can still be used, it is not updated with new data anymore and will remain at the content state of April 2025.

**New data added in the December 2025 release (and upcoming releases) is only available through the BacDive API v2!**

From February 2026, registration through the DSMZ Keycloak server is not required anymore to use the BacDive API.

